### PR TITLE
Update inline validation example description

### DIFF
--- a/www/examples.md
+++ b/www/examples.md
@@ -15,7 +15,7 @@ You can copy and paste them and then adjust them for your needs.
 | [Bulk Update](/examples/bulk-update) | Demonstrates bulk updating of multiple rows of data
 | [Click To Load](/examples/click-to-load) | Demonstrates clicking to load more rows in a table
 | [Lazy Loading](/examples/lazy-load) | Demonstrates how to lazy load content
-| [Inline Validation](/examples/inline-validation) | Demonstrates how to lazy load content
+| [Inline Validation](/examples/inline-validation) | Demonstrates how to do inline field validation
 | [Infinite Scroll](/examples/infinite-scroll) | Demonstrates infinite scrolling of a page
 | [Active Search](/examples/active-search) | Demonstrates the active search box pattern
 | [Progress Bar](/examples/progress-bar) | Demonstrates a job-runner like progress bar


### PR DESCRIPTION
The description for the "Inline Validation" example appeared like it was duplicated from the "Lazy Loading" example's description. The wording may not be ideal, just creating so that it's tracked.